### PR TITLE
Add website restriction compatibility (fixes issue #1)

### DIFF
--- a/src/Controller/Router.php
+++ b/src/Controller/Router.php
@@ -24,6 +24,7 @@ class Router implements \Magento\Framework\App\RouterInterface
     {
         if ($this->config->isEnabled() && trim($request->getPathInfo(), "/") == static::MANIFEST_ENDPOINT) {
             $request
+                ->setRouteName("webappmanifest")
                 ->setModuleName("webappmanifest")
                 ->setControllerName("index")
                 ->setActionName("json");

--- a/src/etc/webrestrictions.xml
+++ b/src/etc/webrestrictions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_WebsiteRestriction:etc/webrestrictions.xsd">
+    <action path="webappmanifest_index_json" type="generic" />
+</config>


### PR DESCRIPTION
This fixes issue #1 where manifest.json doesn't load properly when website restrictions are enabled.

Because the website restrictions module matches webrestrictions.xml entries based on $request->getFullActionName(), the route name needs to be set in Router.php so it produces webappmanifest_index_json (it was previously producing _index_json).

The entry in webrestrictions.xml indicates that the manifest file should be available when restrictions are enabled.